### PR TITLE
Several bug fixes

### DIFF
--- a/src/libws.c
+++ b/src/libws.c
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <assert.h>
+#include <errno.h>
 
 #ifdef LIBWS_HAVE_STDINT_H
 #include <stdint.h>
@@ -594,8 +595,12 @@ char *ws_get_uri(ws_t ws, char *buf, size_t bufsize)
 	}
 
 	// TODO: Check return value?
-	if (evutil_snprintf(buf, bufsize, "%s://%s:%d/%s", 
-		(ws->use_ssl != LIBWS_SSL_OFF) ? "wss" : "ws", 
+	if (evutil_snprintf(buf, bufsize, "%s://%s:%d/%s",
+#ifdef LIBWS_WITH_OPENSSL
+		(ws->use_ssl != LIBWS_SSL_OFF) ? "wss" : "ws",
+#else
+        "ws",
+#endif
 		ws->server,
 		ws->port,
 		ws->uri) < 0)

--- a/src/libws_handshake.c
+++ b/src/libws_handshake.c
@@ -93,6 +93,7 @@ int _ws_send_handshake(ws_t ws, struct evbuffer *out)
 		{
 			evbuffer_add_printf(out, ", %s", ws->subprotocols[i]);
 		}
+        evbuffer_add_printf(out, "\r\n");
 	}
 	
 	evbuffer_add_printf(out, "\r\n");

--- a/src/libws_handshake.c
+++ b/src/libws_handshake.c
@@ -6,10 +6,12 @@
 #include "libws_handshake.h"
 #include "libws_private.h"
 #include "libws_base64.h"
+#include "libws_sha1.h"
 #include <event2/event.h>
 #include <event2/bufferevent.h>
 #include <event2/buffer.h>
 #include <assert.h>
+#include <string.h>
 
 int _ws_generate_handshake_key(ws_t ws)
 {

--- a/src/libws_log.c
+++ b/src/libws_log.c
@@ -35,7 +35,7 @@ char *_ws_get_time_str(char *buf, size_t bufsize)
 	now = localtime(&timenow);
 	strftime(buf, bufsize, fmt, now);
 #else
-	int ret = 0;
+	size_t ret = 0;
 	struct timeval now;
 	evutil_gettimeofday(&now, NULL);
 	ret = strftime(buf, bufsize, fmt, localtime(&now.tv_sec));

--- a/src/libws_private.c
+++ b/src/libws_private.c
@@ -1127,10 +1127,10 @@ int _ws_send_frame_raw(ws_t ws, ws_opcode_t opcode, char *data, uint64_t datalen
 
 	// Pack and send header.
 	{
-		memset(&ws->header, 0, sizeof(ws_header_t));
+		memset(&ws->send_header, 0, sizeof(ws_header_t));
 
-		ws->header.fin = 0x1;
-		ws->header.opcode = opcode;
+		ws->send_header.fin = 0x1;
+		ws->send_header.opcode = opcode;
 		
 		if (datalen > WS_MAX_PAYLOAD_LEN)
 		{
@@ -1140,16 +1140,16 @@ int _ws_send_frame_raw(ws_t ws, ws_opcode_t opcode, char *data, uint64_t datalen
 			return -1;
 		}
 
-		ws->header.mask_bit = 0x1;
-		ws->header.payload_len = datalen;
+		ws->send_header.mask_bit = 0x1;
+		ws->send_header.payload_len = datalen;
 
-		if (_ws_get_random_mask(ws, (char *)&ws->header.mask, sizeof(uint32_t)) 
+		if (_ws_get_random_mask(ws, (char *)&ws->send_header.mask, sizeof(uint32_t)) 
 			!= sizeof(uint32_t))
 		{
 		 	return -1;
 		}
 
-		ws_pack_header(&ws->header, header_buf, sizeof(header_buf), &header_len);
+		ws_pack_header(&ws->send_header, header_buf, sizeof(header_buf), &header_len);
 		
 		if (_ws_send_data(ws, (char *)header_buf, (uint64_t)header_len, 0))
 		{
@@ -1160,7 +1160,7 @@ int _ws_send_frame_raw(ws_t ws, ws_opcode_t opcode, char *data, uint64_t datalen
 
 	// Send the data.
 	{
-		ws_mask_payload(ws->header.mask, data, datalen);
+		ws_mask_payload(ws->send_header.mask, data, datalen);
 
 		if (_ws_send_data(ws, data, datalen, 1))
 		{

--- a/src/libws_private.c
+++ b/src/libws_private.c
@@ -3,6 +3,7 @@
 
 #include <stdio.h>
 #include <assert.h>
+#include <errno.h>
 
 #ifdef WIN32
   #define _CRT_RAND_S
@@ -1288,7 +1289,7 @@ int _ws_get_random_mask(ws_t ws, char *buf, size_t len)
 	}
 	#else
 	int i;
-	i = read(ws->ws_base->random_fd, buf, len);
+	i = (int)read(ws->ws_base->random_fd, buf, len);
 	#endif 
 
 	return i;

--- a/src/libws_private.c
+++ b/src/libws_private.c
@@ -344,10 +344,9 @@ static int _ws_handle_close_frame(ws_t ws)
 			LIBWS_LOG(LIBWS_DEBUG, "Reading server close status and reason "
 					" (payload length %lu)", ws->ctrl_len);
 
-            const char* payload = ws->ctrl_payload;
-            //casting char* to uint16_t*, it breaks strict aliasing
-			ws->server_close_status = 
-                (ws_close_status_t)ntohs((((uint16_t)(payload[0])) << 8) + payload[1]);
+            uint16_t status;
+            memcpy(&status, ws->ctrl_payload, 2);
+			ws->server_close_status = (ws_close_status_t)ntohs(status);
             if (ws->ctrl_len > 2)
             {
                 ws->server_reason = &ws->ctrl_payload[2];

--- a/src/libws_private.c
+++ b/src/libws_private.c
@@ -793,9 +793,8 @@ void ws_read_callback(struct bufferevent *bev, void *ptr)
 		switch ((state = _ws_read_server_handshake_reply(ws, in)))
 		{
 			case WS_PARSE_STATE_ERROR:
-				// TODO: Do anything else here?
-				_ws_shutdown(ws);
-				break;
+                ws_close_with_status(ws, WS_CLOSE_STATUS_PROTOCOL_ERR_1002);
+                return;
 			case WS_PARSE_STATE_NEED_MORE: return;
 			case WS_PARSE_STATE_SUCCESS:
 			{

--- a/src/libws_private.h
+++ b/src/libws_private.h
@@ -230,6 +230,7 @@ typedef struct ws_s
     uint64_t frame_data_sent;   ///< The number of bytes sent so
                                 /// far of the current frame.
     ws_send_state_t send_state; ///< The state for sending data.
+    ws_header_t send_header;    ///< Header for outgoing websocket frame.
     ws_no_copy_cleanup_f no_copy_cleanup_cb;
                                 ///< If set, any data written to
                                 /// the websocket will be freed 


### PR DESCRIPTION
* Fixed compiler warnings (mostly due to missing includes, at least on Mac OS), and a compile error building without SSL.
* Fix for an invalid HTTP request being sent when subprotocols are used.
* Correct (better, at least) handling of a server error from the HTTP request.
* Fix for ws_header_t being shared between reader and writer, causing confusion.
* Fix for errors decoding the server's close status.